### PR TITLE
The ols-ucentral-client src/ucentral-client/proto.c depends on the et…

### DIFF
--- a/schema/ethernet.yml
+++ b/schema/ethernet.yml
@@ -31,6 +31,7 @@ properties:
     - 10000
     - 25000
     - 100000
+    default: 1000
   duplex:
     description:
       The duplex mode that shall be forced.
@@ -38,6 +39,7 @@ properties:
     enum:
     - half
     - full
+    default: full
   enabled:
     description:
       This allows forcing the port to down state by default.


### PR DESCRIPTION
…hernet port speed and duplex values being present, even if the port itself is not enabled:

                enabled =
                        cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(eth, "enabled"));
                duplex =
                        cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(eth, "duplex"));
                speed =
                        cJSON_GetNumberValue(cJSON_GetObjectItemCaseSensitive(eth, "speed"));

                if (!duplex || !speed || !select_ports) {
                        UC_LOG_ERR("Ethernet obj doesn't hold duplex, speed or select-ports fields, parse failed\n");
                        return -1;
                }

While personally I believe it might be better not to care about speed and duplex setting for a port that is disabled, if they are required, it makes sense to define defaults for them in the schema, as it is highly likely that any operator configuring a switch would not think it necessary to define these values on disabled physical ports.

Speed is defaulted to 1000
Duplex is defaulted to full
Signed-off-by: Mike Hansen <mike.hansen@netexperience.com>