### PR TITLE
ethernet-poe-power-limit-and-ipv4-schema-fix

### DIFF
--- a/schema/ethernet.yml
+++ b/schema/ethernet.yml
@@ -94,7 +94,7 @@ properties:
       power-limit:
         description:
           Option to configure user defined absolute power limit PoE port can dain (in milliwatts, mW).
-        type: number
+        type: integer
         default: 99900
       priority:
         description:

--- a/schema/interface.ipv4.yml
+++ b/schema/interface.ipv4.yml
@@ -15,22 +15,13 @@ properties:
     - static
   subnet:
     description:
-      This option defines a list of CONNECTED routes (with VRF id) in CIDR notation.
-    type: array
-    items:
-      type: object
-      properties:
-        prefix:
-          description:
-            Defines a CONNECTED route's prefix (network).
-          type: string
-          format: uc-cidr4
-          examples:
-          - 192.168.1.0/24
-        vrf:
-          description:
-            VRF id.
-          type: number
+      This option defines the static IPv4 of the logical interface in CIDR notation.
+      auto/24 can be used, causing the configuration layer to automatically use
+      and address range from globals.ipv4-network.
+    type: string
+    format: uc-cidr4
+    examples:
+    - 192.168.1.0/24
   gateway:
     description:
       This option defines the static IPv4 gateway of the logical interface.

--- a/schema/interface.ipv4.yml
+++ b/schema/interface.ipv4.yml
@@ -15,13 +15,22 @@ properties:
     - static
   subnet:
     description:
-      This option defines the static IPv4 of the logical interface in CIDR notation.
-      auto/24 can be used, causing the configuration layer to automatically use
-      and address range from globals.ipv4-network.
-    type: string
-    format: uc-cidr4
-    examples:
-    - 192.168.1.0/24
+      This option defines a list of CONNECTED routes (with VRF id) in CIDR notation.
+    type: array
+    items:
+      type: object
+      properties:
+        prefix:
+          description:
+            Defines a CONNECTED route's prefix (network).
+          type: string
+          format: uc-cidr4
+          examples:
+          - 192.168.1.0/24
+        vrf:
+          description:
+            VRF id.
+          type: number
   gateway:
     description:
       This option defines the static IPv4 gateway of the logical interface.

--- a/schema/unit.yml
+++ b/schema/unit.yml
@@ -79,6 +79,6 @@ properties:
       usage-threshold:
         description:
           Configure a power alarm threshold for the Power sourcing equipment (in percentages %).
-        type: number
+        type: integer
         default: 90
 

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -210,6 +210,48 @@ function instantiateUnit(location, value, errors) {
 			obj.beacon_advertisement = parseBeaconAdvertisement(location + "/beacon-advertisement", value["beacon-advertisement"], errors);
 		}
 
+		function parsePoe(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parsePowerManagement(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "power-management")) {
+					obj.power_management = parsePowerManagement(location + "/power-management", value["power-management"], errors);
+				}
+
+				function parseUsageThreshold(location, value, errors) {
+					if (!(type(value) in [ "int", "double" ]))
+						push(errors, [ location, "must be of type number" ]);
+
+					return value;
+				}
+
+				if (exists(value, "usage-threshold")) {
+					obj.usage_threshold = parseUsageThreshold(location + "/usage-threshold", value["usage-threshold"], errors);
+				}
+				else {
+					obj.usage_threshold = 90;
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "poe")) {
+			obj.poe = parsePoe(location + "/poe", value["poe"], errors);
+		}
+
 		return obj;
 	}
 
@@ -410,6 +452,118 @@ function instantiateGlobals(location, value, errors) {
 			obj.wireless_multimedia = parseWirelessMultimedia(location + "/wireless-multimedia", value["wireless-multimedia"], errors);
 		}
 
+		function parseIpv4Blackhole(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) == "object") {
+						let obj = {};
+
+						function parsePrefix(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchUcCidr4(value))
+									push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "prefix")) {
+							obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+						}
+
+						function parseVrf(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "vrf")) {
+							obj.vrf = parseVrf(location + "/vrf", value["vrf"], errors);
+						}
+
+						return obj;
+					}
+
+					if (type(value) != "object")
+						push(errors, [ location, "must be of type object" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ipv4-blackhole")) {
+			obj.ipv4_blackhole = parseIpv4Blackhole(location + "/ipv4-blackhole", value["ipv4-blackhole"], errors);
+		}
+
+		function parseIpv4Unreachable(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) == "object") {
+						let obj = {};
+
+						function parsePrefix(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchUcCidr4(value))
+									push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "prefix")) {
+							obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+						}
+
+						function parseVrf(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "vrf")) {
+							obj.vrf = parseVrf(location + "/vrf", value["vrf"], errors);
+						}
+
+						return obj;
+					}
+
+					if (type(value) != "object")
+						push(errors, [ location, "must be of type object" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ipv4-unreachable")) {
+			obj.ipv4_unreachable = parseIpv4Unreachable(location + "/ipv4-unreachable", value["ipv4-unreachable"], errors);
+		}
+
 		return obj;
 	}
 
@@ -551,14 +705,17 @@ function instantiateEthernet(location, value, errors) {
 			if (type(value) != "int")
 				push(errors, [ location, "must be of type integer" ]);
 
-			if (!(value in [ 10, 100, 1000, 2500, 5000, 10000 ]))
-				push(errors, [ location, "must be one of 10, 100, 1000, 2500, 5000 or 10000" ]);
+			if (!(value in [ 10, 100, 1000, 2500, 5000, 10000, 25000, 100000 ]))
+				push(errors, [ location, "must be one of 10, 100, 1000, 2500, 5000, 10000, 25000 or 100000" ]);
 
 			return value;
 		}
 
 		if (exists(value, "speed")) {
 			obj.speed = parseSpeed(location + "/speed", value["speed"], errors);
+		}
+		else {
+			obj.speed = 1000;
 		}
 
 		function parseDuplex(location, value, errors) {
@@ -573,6 +730,9 @@ function instantiateEthernet(location, value, errors) {
 
 		if (exists(value, "duplex")) {
 			obj.duplex = parseDuplex(location + "/duplex", value["duplex"], errors);
+		}
+		else {
+			obj.duplex = "full";
 		}
 
 		function parseEnabled(location, value, errors) {
@@ -609,6 +769,195 @@ function instantiateEthernet(location, value, errors) {
 
 		if (exists(value, "services")) {
 			obj.services = parseServices(location + "/services", value["services"], errors);
+		}
+
+		function parsePoe(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseAdminMode(location, value, errors) {
+					if (type(value) != "bool")
+						push(errors, [ location, "must be of type boolean" ]);
+
+					return value;
+				}
+
+				if (exists(value, "admin-mode")) {
+					obj.admin_mode = parseAdminMode(location + "/admin-mode", value["admin-mode"], errors);
+				}
+				else {
+					obj.admin_mode = false;
+				}
+
+				function parseDoReset(location, value, errors) {
+					if (type(value) != "bool")
+						push(errors, [ location, "must be of type boolean" ]);
+
+					return value;
+				}
+
+				if (exists(value, "do-reset")) {
+					obj.do_reset = parseDoReset(location + "/do-reset", value["do-reset"], errors);
+				}
+
+				function parseDetection(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "detection")) {
+					obj.detection = parseDetection(location + "/detection", value["detection"], errors);
+				}
+				else {
+					obj.detection = "dot3bt";
+				}
+
+				function parsePowerLimit(location, value, errors) {
+					if (type(value) != "int")
+						push(errors, [ location, "must be of type integer" ]);
+
+					return value;
+				}
+
+				if (exists(value, "power-limit")) {
+					obj.power_limit = parsePowerLimit(location + "/power-limit", value["power-limit"], errors);
+				}
+				else {
+					obj.power_limit = 99900;
+				}
+
+				function parsePriority(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					return value;
+				}
+
+				if (exists(value, "priority")) {
+					obj.priority = parsePriority(location + "/priority", value["priority"], errors);
+				}
+				else {
+					obj.priority = "low";
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "poe")) {
+			obj.poe = parsePoe(location + "/poe", value["poe"], errors);
+		}
+
+		function parseIeee8021x(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseIsAuthenticator(location, value, errors) {
+					if (type(value) != "bool")
+						push(errors, [ location, "must be of type boolean" ]);
+
+					return value;
+				}
+
+				if (exists(value, "is-authenticator")) {
+					obj.is_authenticator = parseIsAuthenticator(location + "/is-authenticator", value["is-authenticator"], errors);
+				}
+				else {
+					obj.is_authenticator = false;
+				}
+
+				function parseAuthenticationMode(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					if (!(value in [ "force-authorized", "force-unauthorized", "auto" ]))
+						push(errors, [ location, "must be one of \"force-authorized\", \"force-unauthorized\" or \"auto\"" ]);
+
+					return value;
+				}
+
+				if (exists(value, "authentication-mode")) {
+					obj.authentication_mode = parseAuthenticationMode(location + "/authentication-mode", value["authentication-mode"], errors);
+				}
+				else {
+					obj.authentication_mode = "force-authorized";
+				}
+
+				function parseHostMode(location, value, errors) {
+					if (type(value) != "string")
+						push(errors, [ location, "must be of type string" ]);
+
+					if (!(value in [ "multi-auth", "multi-domain", "multi-host", "single-host" ]))
+						push(errors, [ location, "must be one of \"multi-auth\", \"multi-domain\", \"multi-host\" or \"single-host\"" ]);
+
+					return value;
+				}
+
+				if (exists(value, "host-mode")) {
+					obj.host_mode = parseHostMode(location + "/host-mode", value["host-mode"], errors);
+				}
+				else {
+					obj.host_mode = "multi-auth";
+				}
+
+				function parseGuestVlan(location, value, errors) {
+					if (type(value) in [ "int", "double" ]) {
+						if (value > 4094)
+							push(errors, [ location, "must be lower than or equal to 4094" ]);
+
+						if (value < 1)
+							push(errors, [ location, "must be bigger than or equal to 1" ]);
+
+					}
+
+					if (type(value) != "int")
+						push(errors, [ location, "must be of type integer" ]);
+
+					return value;
+				}
+
+				if (exists(value, "guest-vlan")) {
+					obj.guest_vlan = parseGuestVlan(location + "/guest-vlan", value["guest-vlan"], errors);
+				}
+
+				function parseUnauthenticatedVlan(location, value, errors) {
+					if (type(value) in [ "int", "double" ]) {
+						if (value > 4094)
+							push(errors, [ location, "must be lower than or equal to 4094" ]);
+
+						if (value < 1)
+							push(errors, [ location, "must be bigger than or equal to 1" ]);
+
+					}
+
+					if (type(value) != "int")
+						push(errors, [ location, "must be of type integer" ]);
+
+					return value;
+				}
+
+				if (exists(value, "unauthenticated-vlan")) {
+					obj.unauthenticated_vlan = parseUnauthenticatedVlan(location + "/unauthenticated-vlan", value["unauthenticated-vlan"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ieee8021x")) {
+			obj.ieee8021x = parseIeee8021x(location + "/ieee8021x", value["ieee8021x"], errors);
 		}
 
 		return obj;
@@ -682,8 +1031,8 @@ function instantiateSwitch(location, value, errors) {
 					if (type(value) != "string")
 						push(errors, [ location, "must be of type string" ]);
 
-					if (!(value in [ "rstp" ]))
-						push(errors, [ location, "must be one of \"rstp\"" ]);
+					if (!(value in [ "none", "stp", "rstp", "mstp", "pvstp", "rpvstp" ]))
+						push(errors, [ location, "must be one of \"none\", \"stp\", \"rstp\", \"mstp\", \"pvstp\" or \"rpvstp\"" ]);
 
 					return value;
 				}
@@ -731,6 +1080,127 @@ function instantiateSwitch(location, value, errors) {
 
 		if (exists(value, "loop-detection")) {
 			obj.loop_detection = parseLoopDetection(location + "/loop-detection", value["loop-detection"], errors);
+		}
+
+		function parseIeee8021x(location, value, errors) {
+			if (type(value) == "object") {
+				let obj = {};
+
+				function parseAuthControlEnable(location, value, errors) {
+					if (type(value) != "bool")
+						push(errors, [ location, "must be of type boolean" ]);
+
+					return value;
+				}
+
+				if (exists(value, "auth-control-enable")) {
+					obj.auth_control_enable = parseAuthControlEnable(location + "/auth-control-enable", value["auth-control-enable"], errors);
+				}
+				else {
+					obj.auth_control_enable = false;
+				}
+
+				function parseRadius(location, value, errors) {
+					if (type(value) == "array") {
+						function parseItem(location, value, errors) {
+							if (type(value) == "object") {
+								let obj = {};
+
+								function parseServerHost(location, value, errors) {
+									if (type(value) != "string")
+										push(errors, [ location, "must be of type string" ]);
+
+									return value;
+								}
+
+								if (exists(value, "server-host")) {
+									obj.server_host = parseServerHost(location + "/server-host", value["server-host"], errors);
+								}
+
+								function parseServerAuthenticationPort(location, value, errors) {
+									if (type(value) in [ "int", "double" ]) {
+										if (value > 65535)
+											push(errors, [ location, "must be lower than or equal to 65535" ]);
+
+										if (value < 1)
+											push(errors, [ location, "must be bigger than or equal to 1" ]);
+
+									}
+
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "server-authentication-port")) {
+									obj.server_authentication_port = parseServerAuthenticationPort(location + "/server-authentication-port", value["server-authentication-port"], errors);
+								}
+
+								function parseServerKey(location, value, errors) {
+									if (type(value) != "string")
+										push(errors, [ location, "must be of type string" ]);
+
+									return value;
+								}
+
+								if (exists(value, "server-key")) {
+									obj.server_key = parseServerKey(location + "/server-key", value["server-key"], errors);
+								}
+
+								function parseServerPriority(location, value, errors) {
+									if (type(value) in [ "int", "double" ]) {
+										if (value > 64)
+											push(errors, [ location, "must be lower than or equal to 64" ]);
+
+										if (value < 1)
+											push(errors, [ location, "must be bigger than or equal to 1" ]);
+
+									}
+
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "server-priority")) {
+									obj.server_priority = parseServerPriority(location + "/server-priority", value["server-priority"], errors);
+								}
+
+								return obj;
+							}
+
+							if (type(value) != "object")
+								push(errors, [ location, "must be of type object" ]);
+
+							return value;
+						}
+
+						return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+					}
+
+					if (type(value) != "array")
+						push(errors, [ location, "must be of type array" ]);
+
+					return value;
+				}
+
+				if (exists(value, "radius")) {
+					obj.radius = parseRadius(location + "/radius", value["radius"], errors);
+				}
+
+				return obj;
+			}
+
+			if (type(value) != "object")
+				push(errors, [ location, "must be of type object" ]);
+
+			return value;
+		}
+
+		if (exists(value, "ieee8021x")) {
+			obj.ieee8021x = parseIeee8021x(location + "/ieee8021x", value["ieee8021x"], errors);
 		}
 
 		return obj;
@@ -1233,6 +1703,17 @@ function instantiateInterfaceVlan(location, value, errors) {
 			obj.proto = "802.1q";
 		}
 
+		function parseStpInstance(location, value, errors) {
+			if (type(value) != "int")
+				push(errors, [ location, "must be of type integer" ]);
+
+			return value;
+		}
+
+		if (exists(value, "stp-instance")) {
+			obj.stp_instance = parseStpInstance(location + "/stp-instance", value["stp-instance"], errors);
+		}
+
 		return obj;
 	}
 
@@ -1696,20 +2177,143 @@ function instantiateInterfaceIpv4(location, value, errors) {
 		}
 
 		function parseGateway(location, value, errors) {
-			if (type(value) == "string") {
-				if (!matchIpv4(value))
-					push(errors, [ location, "must be a valid IPv4 address" ]);
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) == "object") {
+						let obj = {};
 
+						function parsePrefix(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchUcCidr4(value))
+									push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "prefix")) {
+							obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+						}
+
+						function parseNexthop(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchIpv4(value))
+									push(errors, [ location, "must be a valid IPv4 address" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "nexthop")) {
+							obj.nexthop = parseNexthop(location + "/nexthop", value["nexthop"], errors);
+						}
+
+						function parseVrf(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "vrf")) {
+							obj.vrf = parseVrf(location + "/vrf", value["vrf"], errors);
+						}
+
+						function parseMetric(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "metric")) {
+							obj.metric = parseMetric(location + "/metric", value["metric"], errors);
+						}
+
+						return obj;
+					}
+
+					if (type(value) != "object")
+						push(errors, [ location, "must be of type object" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
 			}
 
-			if (type(value) != "string")
-				push(errors, [ location, "must be of type string" ]);
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
 
 			return value;
 		}
 
 		if (exists(value, "gateway")) {
 			obj.gateway = parseGateway(location + "/gateway", value["gateway"], errors);
+		}
+
+		function parseBroadcast(location, value, errors) {
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) == "object") {
+						let obj = {};
+
+						function parsePrefix(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchUcCidr4(value))
+									push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "prefix")) {
+							obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+						}
+
+						function parseVrf(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "vrf")) {
+							obj.vrf = parseVrf(location + "/vrf", value["vrf"], errors);
+						}
+
+						return obj;
+					}
+
+					if (type(value) != "object")
+						push(errors, [ location, "must be of type object" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+			}
+
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
+
+			return value;
+		}
+
+		if (exists(value, "broadcast")) {
+			obj.broadcast = parseBroadcast(location + "/broadcast", value["broadcast"], errors);
 		}
 
 		function parseSendHostname(location, value, errors) {

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -2160,14 +2160,53 @@ function instantiateInterfaceIpv4(location, value, errors) {
 		}
 
 		function parseSubnet(location, value, errors) {
-			if (type(value) == "string") {
-				if (!matchUcCidr4(value))
-					push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+			if (type(value) == "array") {
+				function parseItem(location, value, errors) {
+					if (type(value) == "object") {
+						let obj = {};
 
+						function parsePrefix(location, value, errors) {
+							if (type(value) == "string") {
+								if (!matchUcCidr4(value))
+									push(errors, [ location, "must be a valid IPv4 CIDR" ]);
+
+							}
+
+							if (type(value) != "string")
+								push(errors, [ location, "must be of type string" ]);
+
+							return value;
+						}
+
+						if (exists(value, "prefix")) {
+							obj.prefix = parsePrefix(location + "/prefix", value["prefix"], errors);
+						}
+
+						function parseVrf(location, value, errors) {
+							if (!(type(value) in [ "int", "double" ]))
+								push(errors, [ location, "must be of type number" ]);
+
+							return value;
+						}
+
+						if (exists(value, "vrf")) {
+							obj.vrf = parseVrf(location + "/vrf", value["vrf"], errors);
+						}
+
+						return obj;
+					}
+
+					if (type(value) != "object")
+						push(errors, [ location, "must be of type object" ]);
+
+					return value;
+				}
+
+				return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
 			}
 
-			if (type(value) != "string")
-				push(errors, [ location, "must be of type string" ]);
+			if (type(value) != "array")
+				push(errors, [ location, "must be of type array" ]);
 
 			return value;
 		}

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -226,8 +226,8 @@ function instantiateUnit(location, value, errors) {
 				}
 
 				function parseUsageThreshold(location, value, errors) {
-					if (!(type(value) in [ "int", "double" ]))
-						push(errors, [ location, "must be of type number" ]);
+					if (type(value) != "int")
+						push(errors, [ location, "must be of type integer" ]);
 
 					return value;
 				}

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -66,6 +66,28 @@
                             "type": "integer"
                         }
                     }
+                },
+                "poe": {
+                    "description": "This section describes the system-wide (unit) PoE controller configuration object.",
+                    "type": "object",
+                    "properties": {
+                        "power-management": {
+                            "description": "This configuration mode controls the power management algorithm used by the Power sourcing equipment to deliver power to the requesting PDs. \"class\" option - Class-based power management. \"dynamic\" option - Power management is done by the POE controller and the maximum power for a port is not reserved for each port. \"static\" option - The power deducted from the total power pool is the maximum power for that port. This mode ensures that the maximum power specified by you for the interface is always reserved and cannot be shared by other PDs.",
+                            "type": "string",
+                            "examples": [
+                                "class",
+                                "dynamic",
+                                "dynamic-priority",
+                                "static",
+                                "static-priority"
+                            ]
+                        },
+                        "usage-threshold": {
+                            "description": "Configure a power alarm threshold for the Power sourcing equipment (in percentages %).",
+                            "type": "number",
+                            "default": 90
+                        }
+                    }
                 }
             }
         },
@@ -370,6 +392,48 @@
                             }
                         }
                     ]
+                },
+                "ipv4-blackhole": {
+                    "description": "Define a list of non-interface specific BLACKHOLE (to-nowhere) routes.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a BLACKHOLE route's prefix.",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
+                },
+                "ipv4-unreachable": {
+                    "description": "Define a list of non-interface specific UNREACHABLE routes.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a UNREACHABLE route's prefix.",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -468,8 +532,11 @@
                             1000,
                             2500,
                             5000,
-                            10000
-                        ]
+                            10000,
+                            25000,
+                            100000
+                        ],
+                        "default": 1000
                     },
                     "duplex": {
                         "description": "The duplex mode that shall be forced.",
@@ -477,7 +544,8 @@
                         "enum": [
                             "half",
                             "full"
-                        ]
+                        ],
+                        "default": "full"
                     },
                     "enabled": {
                         "description": "This allows forcing the port to down state by default.",
@@ -492,6 +560,95 @@
                             "examples": [
                                 "quality-of-service"
                             ]
+                        }
+                    },
+                    "poe": {
+                        "description": "This section describes the ethernet poe-port configuration object.",
+                        "type": "object",
+                        "properties": {
+                            "admin-mode": {
+                                "description": "Option to force admin state over selected port. Setting to <false> immediately shuts down power. Setting to <true> starts PoE hanshake (Power sourcing equipment < - > Powered Device) sequence and in case of success, power is being delivered to Powered Device.",
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "do-reset": {
+                                "description": "Option to force device's PSE (Power sourcing equipment) to invoke a PoE port reset sequence. This option can be used to reset PoE port without flickering it via <admin-mode> down/up sequence.",
+                                "type": "boolean"
+                            },
+                            "detection": {
+                                "description": "The detection mode is used to set the type of devices that are allowed for powering up. The PoE controller can be configured to detect only IEEE standard devices or pre-IEEE legacy devices (which were pre-standard - non-IEEE 802.3af compliant). For example, if \"dot3af\" is used (PoE, max up to 15.4 W), and Powered Device drains >15.4W, Power sourcing equipment won't allow this port to drain power.",
+                                "type": "string",
+                                "examples": [
+                                    "2pt-dot3af",
+                                    "2pt-dot3af+legacy",
+                                    "4pt-dot3af",
+                                    "4pt-dot3af+legacy",
+                                    "dot3bt",
+                                    "dot3bt+legacy",
+                                    "legacy"
+                                ],
+                                "default": "dot3bt"
+                            },
+                            "power-limit": {
+                                "description": "Option to configure user defined absolute power limit PoE port can dain (in milliwatts, mW).",
+                                "type": "integer",
+                                "default": 99900
+                            },
+                            "priority": {
+                                "description": "Option to set priority to each PoE port. When the PoE switch has less power available and more ports are required to supply power, higher priority ports are receive power in preference to lower priority ports.",
+                                "type": "string",
+                                "default": "low",
+                                "examples": [
+                                    "critical",
+                                    "high",
+                                    "medium",
+                                    "low"
+                                ]
+                            }
+                        }
+                    },
+                    "ieee8021x": {
+                        "description": "This section describes the per-port specific 802.1X (port access control) configuration.",
+                        "type": "object",
+                        "properties": {
+                            "is-authenticator": {
+                                "description": "Configure PAE processing on port, as well as select this port as an Authenticator (configure PAC role to authenticator). False configures the switch to not process PAC",
+                                "type": "boolean",
+                                "default": false
+                            },
+                            "authentication-mode": {
+                                "description": "Configure PAE processing on port, as well as select this port as an Authenticator (configure PAC role to authenticator). force-authorized - Disables IEEE 802.1X authentication and causes the port to change to the authorized state without any authentication exchange required. The port sends and receives normal traffic without IEEE 802.1X-based authentication of the client. force-unauthorized - Causes the port to remain in the unauthorized state, ignoring all attempts by the supplicant to authenticate. The Device cannot provide authentication services to the supplicant through the port. auto - Enables IEEE 802.1X authentication and causes the port to begin in the unauthorized state, allowing only EAPOL frames to be sent and received through the port. The authentication process begins when the link state of the port changes from down to up or when an EAPOL-start frame is received. The Device requests the identity of the supplicant and begins relaying authentication messages between the supplicant and the authentication server. Each supplicant attempting to access the network is uniquely identified by the Device by using the supplicant MAC address.",
+                                "type": "string",
+                                "enum": [
+                                    "force-authorized",
+                                    "force-unauthorized",
+                                    "auto"
+                                ],
+                                "default": "force-authorized"
+                            },
+                            "host-mode": {
+                                "description": "Multi-auth \u2014 While in this mode, multiple devices are allowed to independently authenticate through the same port. Multi-domain \u2014 While in this mode, the authenticator will allow one host from the data domain and one from the voice domain. Multi-host \u2014 While in this mode, the first device to authenticate will open to the switchport so that all other devices can use the port. These other devices are not required to be authenticated independently. Single-host - While in this mode, the switchport will only allow a single host to be authenticated and to pass traffic at a time.",
+                                "type": "string",
+                                "enum": [
+                                    "multi-auth",
+                                    "multi-domain",
+                                    "multi-host",
+                                    "single-host"
+                                ],
+                                "default": "multi-auth"
+                            },
+                            "guest-vlan": {
+                                "description": "Configure a VLAN as a guest VLAN on an interface if the switch receives no response in an authentication event.",
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 4094
+                            },
+                            "unauthenticated-vlan": {
+                                "description": "Configure the unauthenticated VLAN to use when the AAA server fails to recognize the client credentials",
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 4094
+                            }
                         }
                     }
                 }
@@ -526,7 +683,12 @@
                             "description": "Define which protocol shall be used for loop detection.",
                             "type": "string",
                             "enum": [
-                                "rstp"
+                                "none",
+                                "stp",
+                                "rstp",
+                                "mstp",
+                                "pvstp",
+                                "rpvstp"
                             ],
                             "default": "rstp"
                         },
@@ -539,6 +701,91 @@
                                     "upstream",
                                     "downstream"
                                 ]
+                            }
+                        }
+                    },
+                    "instances": {
+                        "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
+                                    "type": "integer"
+                                },
+                                "enabled": {
+                                    "description": "Enable STP on this instance.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "priority": {
+                                    "description": "Bridge priority.",
+                                    "type": "integer",
+                                    "default": 32768
+                                },
+                                "forward_delay": {
+                                    "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
+                                    "type": "integer",
+                                    "default": 15
+                                },
+                                "hellow_time": {
+                                    "description": "Determines how often switches send BPDU.",
+                                    "type": "integer",
+                                    "default": 2
+                                },
+                                "max_age": {
+                                    "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
+                                    "type": "integer",
+                                    "default": 20
+                                }
+                            }
+                        }
+                    }
+                },
+                "ieee8021x": {
+                    "description": "This section describes the global 802.1X (port access control) configuration.",
+                    "type": "object",
+                    "properties": {
+                        "auth-control-enable": {
+                            "description": "Enabled processing of PAE frames on ports that have .1X configured.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "radius": {
+                            "description": "Define a list of RADIUS server to forward auth requests to.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "server-host": {
+                                        "description": "Remote radius server address (IP or hostname).",
+                                        "type": "string",
+                                        "examples": [
+                                            "192.168.1.1",
+                                            "somehost.com"
+                                        ]
+                                    },
+                                    "server-authentication-port": {
+                                        "description": "The port that the RADIUS authentication agent is running on.",
+                                        "type": "integer",
+                                        "maximum": 65535,
+                                        "minimum": 1
+                                    },
+                                    "server-key": {
+                                        "description": "Secret key text that is shared between a RADIUS server and the switch.",
+                                        "type": "string",
+                                        "examples": [
+                                            "somepassword"
+                                        ]
+                                    },
+                                    "server-priority": {
+                                        "description": "The server's priority (used when multiple servers are present. Bigger prio value = higher priority).",
+                                        "type": "integer",
+                                        "maximum": 64,
+                                        "minimum": 1
+                                    }
+                                }
                             }
                         }
                     }
@@ -846,6 +1093,10 @@
                                     "802.1q"
                                 ],
                                 "default": "802.1q"
+                            },
+                            "stp-instance": {
+                                "decription": "MSTP instance identifier of the vlan. This field does nothing if MSTP is not enabled.",
+                                "type": "integer"
                             }
                         }
                     },
@@ -957,16 +1208,62 @@
                                 "type": "string",
                                 "format": "uc-cidr4",
                                 "examples": [
-                                    "auto/24"
+                                    "192.168.1.0/24"
                                 ]
                             },
                             "gateway": {
                                 "description": "This option defines the static IPv4 gateway of the logical interface.",
-                                "type": "string",
-                                "format": "ipv4",
-                                "examples": [
-                                    "192.168.1.1"
-                                ]
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prefix": {
+                                            "description": "Defines a NEXTHOP route's prefix (network).",
+                                            "type": "string",
+                                            "format": "uc-cidr4",
+                                            "examples": [
+                                                "192.168.1.0/24"
+                                            ]
+                                        },
+                                        "nexthop": {
+                                            "description": "Gateway (nexthop) address.",
+                                            "type": "string",
+                                            "format": "ipv4",
+                                            "examples": [
+                                                "192.168.1.1"
+                                            ]
+                                        },
+                                        "vrf": {
+                                            "description": "VRF id.",
+                                            "type": "number"
+                                        },
+                                        "metric": {
+                                            "description": "Optional metric value (define a NH route's weight / metric).",
+                                            "type": "number"
+                                        }
+                                    }
+                                }
+                            },
+                            "broadcast": {
+                                "description": "This option defines a list of BROADCAST routes (with VRF id) in CIDR notation.",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prefix": {
+                                            "description": "Defines a BROADCAST route's prefix (network).",
+                                            "type": "string",
+                                            "format": "uc-cidr4",
+                                            "examples": [
+                                                "192.168.1.0/24"
+                                            ]
+                                        },
+                                        "vrf": {
+                                            "description": "VRF id.",
+                                            "type": "number"
+                                        }
+                                    }
+                                }
                             },
                             "send-hostname": {
                                 "description": "include the devices hostname inside DHCP requests",

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -1204,12 +1204,25 @@
                                 ]
                             },
                             "subnet": {
-                                "description": "This option defines the static IPv4 of the logical interface in CIDR notation. auto/24 can be used, causing the configuration layer to automatically use and address range from globals.ipv4-network.",
-                                "type": "string",
-                                "format": "uc-cidr4",
-                                "examples": [
-                                    "192.168.1.0/24"
-                                ]
+                                "description": "This option defines a list of CONNECTED routes (with VRF id) in CIDR notation.",
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "prefix": {
+                                            "description": "Defines a CONNECTED route's prefix (network).",
+                                            "type": "string",
+                                            "format": "uc-cidr4",
+                                            "examples": [
+                                                "192.168.1.0/24"
+                                            ]
+                                        },
+                                        "vrf": {
+                                            "description": "VRF id.",
+                                            "type": "number"
+                                        }
+                                    }
+                                }
                             },
                             "gateway": {
                                 "description": "This option defines the static IPv4 gateway of the logical interface.",

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -84,7 +84,7 @@
                         },
                         "usage-threshold": {
                             "description": "Configure a power alarm threshold for the Power sourcing equipment (in percentages %).",
-                            "type": "number",
+                            "type": "integer",
                             "default": 90
                         }
                     }

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -349,14 +349,16 @@
                         10000,
                         25000,
                         100000
-                    ]
+                    ],
+                    "default": 1000
                 },
                 "duplex": {
                     "type": "string",
                     "enum": [
                         "half",
                         "full"
-                    ]
+                    ],
+                    "default": "full"
                 },
                 "enabled": {
                     "type": "boolean",
@@ -395,7 +397,7 @@
                             "default": "dot3bt"
                         },
                         "power-limit": {
-                            "type": "number",
+                            "type": "integer",
                             "default": 99900
                         },
                         "priority": {
@@ -969,22 +971,11 @@
                     ]
                 },
                 "subnet": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "prefix": {
-                                "type": "string",
-                                "format": "uc-cidr4",
-                                "examples": [
-                                    "192.168.1.0/24"
-                                ]
-                            },
-                            "vrf": {
-                                "type": "number"
-                            }
-                        }
-                    }
+                    "type": "string",
+                    "format": "uc-cidr4",
+                    "examples": [
+                        "192.168.1.0/24"
+                    ]
                 },
                 "gateway": {
                     "type": "array",

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -971,11 +971,22 @@
                     ]
                 },
                 "subnet": {
-                    "type": "string",
-                    "format": "uc-cidr4",
-                    "examples": [
-                        "192.168.1.0/24"
-                    ]
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "type": "number"
+                            }
+                        }
+                    }
                 },
                 "gateway": {
                     "type": "array",

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -112,7 +112,7 @@
                             ]
                         },
                         "usage-threshold": {
-                            "type": "number",
+                            "type": "integer",
                             "default": 90
                         }
                     }

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -1099,12 +1099,25 @@
                     ]
                 },
                 "subnet": {
-                    "description": "This option defines the static IPv4 of the logical interface in CIDR notation. auto/24 can be used, causing the configuration layer to automatically use and address range from globals.ipv4-network.",
-                    "type": "string",
-                    "format": "uc-cidr4",
-                    "examples": [
-                        "192.168.1.0/24"
-                    ]
+                    "description": "This option defines a list of CONNECTED routes (with VRF id) in CIDR notation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a CONNECTED route's prefix (network).",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
                 },
                 "gateway": {
                     "description": "This option defines the static IPv4 gateway of the logical interface.",

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -111,6 +111,28 @@
                             "type": "integer"
                         }
                     }
+                },
+                "poe": {
+                    "description": "This section describes the system-wide (unit) PoE controller configuration object.",
+                    "type": "object",
+                    "properties": {
+                        "power-management": {
+                            "description": "This configuration mode controls the power management algorithm used by the Power sourcing equipment to deliver power to the requesting PDs. \"class\" option - Class-based power management. \"dynamic\" option - Power management is done by the POE controller and the maximum power for a port is not reserved for each port. \"static\" option - The power deducted from the total power pool is the maximum power for that port. This mode ensures that the maximum power specified by you for the interface is always reserved and cannot be shared by other PDs.",
+                            "type": "string",
+                            "examples": [
+                                "class",
+                                "dynamic",
+                                "dynamic-priority",
+                                "static",
+                                "static-priority"
+                            ]
+                        },
+                        "usage-threshold": {
+                            "description": "Configure a power alarm threshold for the Power sourcing equipment (in percentages %).",
+                            "type": "number",
+                            "default": 90
+                        }
+                    }
                 }
             }
         },
@@ -221,6 +243,48 @@
                             "$ref": "#/$defs/globals.wireless-multimedia.profile"
                         }
                     ]
+                },
+                "ipv4-blackhole": {
+                    "description": "Define a list of non-interface specific BLACKHOLE (to-nowhere) routes.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a BLACKHOLE route's prefix.",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
+                },
+                "ipv4-unreachable": {
+                    "description": "Define a list of non-interface specific UNREACHABLE routes.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a UNREACHABLE route's prefix.",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -320,8 +384,11 @@
                         1000,
                         2500,
                         5000,
-                        10000
-                    ]
+                        10000,
+                        25000,
+                        100000
+                    ],
+                    "default": 1000
                 },
                 "duplex": {
                     "description": "The duplex mode that shall be forced.",
@@ -329,7 +396,8 @@
                     "enum": [
                         "half",
                         "full"
-                    ]
+                    ],
+                    "default": "full"
                 },
                 "enabled": {
                     "description": "This allows forcing the port to down state by default.",
@@ -344,6 +412,95 @@
                         "examples": [
                             "quality-of-service"
                         ]
+                    }
+                },
+                "poe": {
+                    "description": "This section describes the ethernet poe-port configuration object.",
+                    "type": "object",
+                    "properties": {
+                        "admin-mode": {
+                            "description": "Option to force admin state over selected port. Setting to <false> immediately shuts down power. Setting to <true> starts PoE hanshake (Power sourcing equipment < - > Powered Device) sequence and in case of success, power is being delivered to Powered Device.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "do-reset": {
+                            "description": "Option to force device's PSE (Power sourcing equipment) to invoke a PoE port reset sequence. This option can be used to reset PoE port without flickering it via <admin-mode> down/up sequence.",
+                            "type": "boolean"
+                        },
+                        "detection": {
+                            "description": "The detection mode is used to set the type of devices that are allowed for powering up. The PoE controller can be configured to detect only IEEE standard devices or pre-IEEE legacy devices (which were pre-standard - non-IEEE 802.3af compliant). For example, if \"dot3af\" is used (PoE, max up to 15.4 W), and Powered Device drains >15.4W, Power sourcing equipment won't allow this port to drain power.",
+                            "type": "string",
+                            "examples": [
+                                "2pt-dot3af",
+                                "2pt-dot3af+legacy",
+                                "4pt-dot3af",
+                                "4pt-dot3af+legacy",
+                                "dot3bt",
+                                "dot3bt+legacy",
+                                "legacy"
+                            ],
+                            "default": "dot3bt"
+                        },
+                        "power-limit": {
+                            "description": "Option to configure user defined absolute power limit PoE port can dain (in milliwatts, mW).",
+                            "type": "integer",
+                            "default": 99900
+                        },
+                        "priority": {
+                            "description": "Option to set priority to each PoE port. When the PoE switch has less power available and more ports are required to supply power, higher priority ports are receive power in preference to lower priority ports.",
+                            "type": "string",
+                            "default": "low",
+                            "examples": [
+                                "critical",
+                                "high",
+                                "medium",
+                                "low"
+                            ]
+                        }
+                    }
+                },
+                "ieee8021x": {
+                    "description": "This section describes the per-port specific 802.1X (port access control) configuration.",
+                    "type": "object",
+                    "properties": {
+                        "is-authenticator": {
+                            "description": "Configure PAE processing on port, as well as select this port as an Authenticator (configure PAC role to authenticator). False configures the switch to not process PAC",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "authentication-mode": {
+                            "description": "Configure PAE processing on port, as well as select this port as an Authenticator (configure PAC role to authenticator). force-authorized - Disables IEEE 802.1X authentication and causes the port to change to the authorized state without any authentication exchange required. The port sends and receives normal traffic without IEEE 802.1X-based authentication of the client. force-unauthorized - Causes the port to remain in the unauthorized state, ignoring all attempts by the supplicant to authenticate. The Device cannot provide authentication services to the supplicant through the port. auto - Enables IEEE 802.1X authentication and causes the port to begin in the unauthorized state, allowing only EAPOL frames to be sent and received through the port. The authentication process begins when the link state of the port changes from down to up or when an EAPOL-start frame is received. The Device requests the identity of the supplicant and begins relaying authentication messages between the supplicant and the authentication server. Each supplicant attempting to access the network is uniquely identified by the Device by using the supplicant MAC address.",
+                            "type": "string",
+                            "enum": [
+                                "force-authorized",
+                                "force-unauthorized",
+                                "auto"
+                            ],
+                            "default": "force-authorized"
+                        },
+                        "host-mode": {
+                            "description": "Multi-auth \u2014 While in this mode, multiple devices are allowed to independently authenticate through the same port. Multi-domain \u2014 While in this mode, the authenticator will allow one host from the data domain and one from the voice domain. Multi-host \u2014 While in this mode, the first device to authenticate will open to the switchport so that all other devices can use the port. These other devices are not required to be authenticated independently. Single-host - While in this mode, the switchport will only allow a single host to be authenticated and to pass traffic at a time.",
+                            "type": "string",
+                            "enum": [
+                                "multi-auth",
+                                "multi-domain",
+                                "multi-host",
+                                "single-host"
+                            ],
+                            "default": "multi-auth"
+                        },
+                        "guest-vlan": {
+                            "description": "Configure a VLAN as a guest VLAN on an interface if the switch receives no response in an authentication event.",
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094
+                        },
+                        "unauthenticated-vlan": {
+                            "description": "Configure the unauthenticated VLAN to use when the AAA server fails to recognize the client credentials",
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 4094
+                        }
                     }
                 }
             }
@@ -377,7 +534,12 @@
                             "description": "Define which protocol shall be used for loop detection.",
                             "type": "string",
                             "enum": [
-                                "rstp"
+                                "none",
+                                "stp",
+                                "rstp",
+                                "mstp",
+                                "pvstp",
+                                "rpvstp"
                             ],
                             "default": "rstp"
                         },
@@ -390,6 +552,91 @@
                                     "upstream",
                                     "downstream"
                                 ]
+                            }
+                        }
+                    },
+                    "instances": {
+                        "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
+                                    "type": "integer"
+                                },
+                                "enabled": {
+                                    "description": "Enable STP on this instance.",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "priority": {
+                                    "description": "Bridge priority.",
+                                    "type": "integer",
+                                    "default": 32768
+                                },
+                                "forward_delay": {
+                                    "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
+                                    "type": "integer",
+                                    "default": 15
+                                },
+                                "hellow_time": {
+                                    "description": "Determines how often switches send BPDU.",
+                                    "type": "integer",
+                                    "default": 2
+                                },
+                                "max_age": {
+                                    "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
+                                    "type": "integer",
+                                    "default": 20
+                                }
+                            }
+                        }
+                    }
+                },
+                "ieee8021x": {
+                    "description": "This section describes the global 802.1X (port access control) configuration.",
+                    "type": "object",
+                    "properties": {
+                        "auth-control-enable": {
+                            "description": "Enabled processing of PAE frames on ports that have .1X configured.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "radius": {
+                            "description": "Define a list of RADIUS server to forward auth requests to.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "server-host": {
+                                        "description": "Remote radius server address (IP or hostname).",
+                                        "type": "string",
+                                        "examples": [
+                                            "192.168.1.1",
+                                            "somehost.com"
+                                        ]
+                                    },
+                                    "server-authentication-port": {
+                                        "description": "The port that the RADIUS authentication agent is running on.",
+                                        "type": "integer",
+                                        "maximum": 65535,
+                                        "minimum": 1
+                                    },
+                                    "server-key": {
+                                        "description": "Secret key text that is shared between a RADIUS server and the switch.",
+                                        "type": "string",
+                                        "examples": [
+                                            "somepassword"
+                                        ]
+                                    },
+                                    "server-priority": {
+                                        "description": "The server's priority (used when multiple servers are present. Bigger prio value = higher priority).",
+                                        "type": "integer",
+                                        "maximum": 64,
+                                        "minimum": 1
+                                    }
+                                }
                             }
                         }
                     }
@@ -640,6 +887,10 @@
                         "802.1q"
                     ],
                     "default": "802.1q"
+                },
+                "stp-instance": {
+                    "decription": "MSTP instance identifier of the vlan. This field does nothing if MSTP is not enabled.",
+                    "type": "integer"
                 }
             }
         },
@@ -852,16 +1103,62 @@
                     "type": "string",
                     "format": "uc-cidr4",
                     "examples": [
-                        "auto/24"
+                        "192.168.1.0/24"
                     ]
                 },
                 "gateway": {
                     "description": "This option defines the static IPv4 gateway of the logical interface.",
-                    "type": "string",
-                    "format": "ipv4",
-                    "examples": [
-                        "192.168.1.1"
-                    ]
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a NEXTHOP route's prefix (network).",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "nexthop": {
+                                "description": "Gateway (nexthop) address.",
+                                "type": "string",
+                                "format": "ipv4",
+                                "examples": [
+                                    "192.168.1.1"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            },
+                            "metric": {
+                                "description": "Optional metric value (define a NH route's weight / metric).",
+                                "type": "number"
+                            }
+                        }
+                    }
+                },
+                "broadcast": {
+                    "description": "This option defines a list of BROADCAST routes (with VRF id) in CIDR notation.",
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "prefix": {
+                                "description": "Defines a BROADCAST route's prefix (network).",
+                                "type": "string",
+                                "format": "uc-cidr4",
+                                "examples": [
+                                    "192.168.1.0/24"
+                                ]
+                            },
+                            "vrf": {
+                                "description": "VRF id.",
+                                "type": "number"
+                            }
+                        }
+                    }
                 },
                 "send-hostname": {
                     "description": "include the devices hostname inside DHCP requests",

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -129,7 +129,7 @@
                         },
                         "usage-threshold": {
                             "description": "Configure a power alarm threshold for the Power sourcing equipment (in percentages %).",
-                            "type": "number",
+                            "type": "integer",
                             "default": 90
                         }
                     }

--- a/ucentral.state.pretty.json
+++ b/ucentral.state.pretty.json
@@ -132,6 +132,32 @@
                     "items": {
                         "type": "number"
                     }
+                },
+                "poe": {
+                    "description": "This section describes the current state of the PoE unit on the device",
+                    "type": "object",
+                    "properties": {
+                        "max-power-budget": {
+                            "description": "Reports the total power available (power budget) (in watts, W) device's Power sourcing equipment is able to source.",
+                            "type": "number"
+                        },
+                        "power-threshold": {
+                            "description": "Reports configured power alarm threshold value for the Power sourcing equipment (in milliwatts, mW).",
+                            "type": "number"
+                        },
+                        "power-consumed": {
+                            "description": "Reports a total power Powered Devices are draining from the device's Power sourcing equipment (in milliwatts, mW).",
+                            "type": "number"
+                        },
+                        "power-status": {
+                            "description": "Reports power status of the device's Power sourcing equipment.",
+                            "type": "string",
+                            "examples": [
+                                "ON",
+                                "OFF"
+                            ]
+                        }
+                    }
                 }
             }
         },
@@ -767,6 +793,124 @@
                 },
                 "counters": {
                     "$ref": "#/$defs/interface.counter"
+                },
+                "poe": {
+                    "description": "This section describes the ethernet poe-port link-state object (statistics + PD info). Present only in case if port has any Power sourcing capabilities.",
+                    "type": "object",
+                    "properties": {
+                        "class-requested": {
+                            "description": "Reports which PoE power class PD requested.",
+                            "type": "number"
+                        },
+                        "class-assigned": {
+                            "description": "Reports which PoE power class PD has been assigned by the Power sourcing equipment.",
+                            "type": "number"
+                        },
+                        "output-power": {
+                            "description": "Reports the power-value (in milliwatts, mW) poe-port's Powered Device is currently draining.",
+                            "type": "number"
+                        },
+                        "output-current": {
+                            "description": "Reports the current value (in milliamps, mA) poe-port's Powered Device is currently draining.",
+                            "type": "number"
+                        },
+                        "output-voltage": {
+                            "description": "Reports the operational voltage-level-value of poe-port's Power sourcing equipment (in Volts, V).",
+                            "type": "string",
+                            "examples": [
+                                "54.14"
+                            ]
+                        },
+                        "temp": {
+                            "description": "Reports the operational temperature of poe-port's Power sourcing equipment (in Celsius, C).",
+                            "type": "string",
+                            "examples": [
+                                "22.5"
+                            ]
+                        },
+                        "status": {
+                            "description": "Reports the operational status of poe-port's Power sourcing equipment. Searching option - the poe-port's PSE is trying to detect a Powered Device. Delivering option - the poe-port's PSE is delivering power to a Powered Device. Disabled option - the poe-port's PSE is either disabled or PoE power is enabled but the PoE module does not have enough power available to supply the port's power needs. Fault option - the poe-port's PSE detects a problem with the Powered Device. Other Fault option - the PSE has detected an internal fault that prevents it from supplying power on that port.",
+                            "type": "string",
+                            "examples": [
+                                "DELIVERING_POWER",
+                                "DISABLED"
+                            ]
+                        },
+                        "fault-status": {
+                            "description": "Reports the fault status of poe-port's PSE (in case if any).",
+                            "type": "string",
+                            "examples": [
+                                "NO_ERROR"
+                            ]
+                        },
+                        "counters": {
+                            "description": null,
+                            "type": "object",
+                            "properties": {
+                                "overload": {
+                                    "description": "Displays the total number of power overload occurrences. (Powered Device is consuming more power than the maximum limit of a port)",
+                                    "type": "number"
+                                },
+                                "short": {
+                                    "description": "Displays the total number of power shortage occurrences.",
+                                    "type": "number"
+                                },
+                                "power-denied": {
+                                    "description": "Displays the number of times that the powered device was denied power. (possible cause could be that Requested power exceeds PSE capability)",
+                                    "type": "number"
+                                },
+                                "absent": {
+                                    "description": "Displays the number of times that the power was stopped to the powered device because the powered device was no longer detected.",
+                                    "type": "number"
+                                },
+                                "invalid-signature": {
+                                    "description": "Displays the times that an invalid signature was received. Signatures are the means by which the powered device identifies itself to the PSE. Signatures are generated during powered device detection, classification, or maintenance.",
+                                    "type": "number"
+                                }
+                            }
+                        }
+                    }
+                },
+                "ieee8021x": {
+                    "description": "This section describes the per-port specific 802.1X (port access control) link-state object (authenticated clients). Present only in case if port has enabled EAP processing and has any authenticated clients.",
+                    "type": "object",
+                    "properties": {
+                        "authenticated-clients": {
+                            "description": "List of authenticated clients and (their) authentication data.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "authenticated-method": {
+                                        "description": "Authentication method used by client for it's authentication.",
+                                        "type": "string"
+                                    },
+                                    "mac-address": {
+                                        "description": "MAC address of authenticated client.",
+                                        "type": "string",
+                                        "format": "uc-mac"
+                                    },
+                                    "session-time": {
+                                        "description": "Client session time.",
+                                        "type": "integer"
+                                    },
+                                    "username": {
+                                        "description": "Client username.",
+                                        "type": "string"
+                                    },
+                                    "vlan-type": {
+                                        "description": "Vlan type of authenticated client (Authorization status of the client).",
+                                        "type": "string"
+                                    },
+                                    "vlan-id": {
+                                        "description": "Vlan type of authenticated client (Authorization status of the client).",
+                                        "type": "integer",
+                                        "maximum": 4095
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes ipv4 subnet to be a string, aligning with ols-ucentral-client src/ucentral-client/proto.c
    
Change schema/ethernet/poe/power-limit to be an integer instead of a number. Any autogenerated classes from the schema would otherwise be sending decimal values (float or double) and this has been observed to cause issue on some devices. All examples are already shown as integers. 

Change schema/unit/poe/usage-threshold to be an integer instead of a number for reasons similar to above change with power-limit.

The schema examples in the ols-ucentral-client/config-examples now all validate against JSON spec and ucentral.schema.pretty.json, they were failing in the ipv4 and ieee8021x examples due to the string value for subnet against the array definintion in schema.

Noticed the generated json files and the schemareader.uc were not updated since initial repository delivery so I rebuilt them and submitted as well. The schemareader.uc can now be used on the devices if desired and the json files can be used to validate the example configs.