### PR TITLE
Correct indentation of instances block in switch.yml

### DIFF
--- a/schema/switch.yml
+++ b/schema/switch.yml
@@ -43,50 +43,50 @@ properties:
           enum:
           - upstream
           - downstream
-    instances:
-      description:
-        Define a list of configuration for each STP instance.
-        Meaning of this field depends on current
-        STP protocol (switch.loop-detection.protocol)
-      type: array
-      items:
-        type: object
-        properties:
-          id:
-            description:
-              Indicates instance to configure.
-              Depends on current STP protocol
-              If RPVSTP/PVSTP - vlan id
-              If MSTP - instance id
-            type: integer
-          enabled:
-            description:
-              Enable STP on this instance.
-            type: boolean
-            default: true
-          priority:
-            description:
-              Bridge priority.
-            type: integer
-            default: 32768
-          forward_delay:
-            description:
-              Defines the amount of time a switch port stays in the Listening
-              and Learning states before transitioning to the Forwarding state.
-            type: integer
-            default: 15
-          hello_time:
-            description:
-              Determines how often switches send BPDU.
-            type: integer
-            default: 2
-          max_age:
-            description:
-              Specifies the maximum time that a switch port should wait to
-              receive a BPDU from its neighbor before
-              considering the link as failed or disconnected.
-            type: integer
-            default: 20
+      instances:
+        description:
+          Define a list of configuration for each STP instance.
+          Meaning of this field depends on current
+          STP protocol (switch.loop-detection.protocol)
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              description:
+                Indicates instance to configure.
+                Depends on current STP protocol
+                If RPVSTP/PVSTP - vlan id
+                If MSTP - instance id
+              type: integer
+            enabled:
+              description:
+                Enable STP on this instance.
+              type: boolean
+              default: true
+            priority:
+              description:
+                Bridge priority.
+              type: integer
+              default: 32768
+            forward_delay:
+              description:
+                Defines the amount of time a switch port stays in the Listening
+                and Learning states before transitioning to the Forwarding state.
+              type: integer
+              default: 15
+            hello_time:
+              description:
+                Determines how often switches send BPDU.
+              type: integer
+              default: 2
+            max_age:
+              description:
+                Specifies the maximum time that a switch port should wait to
+                receive a BPDU from its neighbor before
+                considering the link as failed or disconnected.
+              type: integer
+              default: 20
   ieee8021x:
     description:
       This section describes the global 802.1X (port access control) configuration.

--- a/schemareader.uc
+++ b/schemareader.uc
@@ -1259,6 +1259,115 @@ function instantiateSwitch(location, value, errors) {
 					obj.roles = parseRoles(location + "/roles", value["roles"], errors);
 				}
 
+				function parseInstances(location, value, errors) {
+					if (type(value) == "array") {
+						function parseItem(location, value, errors) {
+							if (type(value) == "object") {
+								let obj = {};
+
+								function parseId(location, value, errors) {
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "id")) {
+									obj.id = parseId(location + "/id", value["id"], errors);
+								}
+
+								function parseEnabled(location, value, errors) {
+									if (type(value) != "bool")
+										push(errors, [ location, "must be of type boolean" ]);
+
+									return value;
+								}
+
+								if (exists(value, "enabled")) {
+									obj.enabled = parseEnabled(location + "/enabled", value["enabled"], errors);
+								}
+								else {
+									obj.enabled = true;
+								}
+
+								function parsePriority(location, value, errors) {
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "priority")) {
+									obj.priority = parsePriority(location + "/priority", value["priority"], errors);
+								}
+								else {
+									obj.priority = 32768;
+								}
+
+								function parseForward_delay(location, value, errors) {
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "forward_delay")) {
+									obj.forward_delay = parseForward_delay(location + "/forward_delay", value["forward_delay"], errors);
+								}
+								else {
+									obj.forward_delay = 15;
+								}
+
+								function parseHello_time(location, value, errors) {
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "hello_time")) {
+									obj.hello_time = parseHello_time(location + "/hello_time", value["hello_time"], errors);
+								}
+								else {
+									obj.hello_time = 2;
+								}
+
+								function parseMax_age(location, value, errors) {
+									if (type(value) != "int")
+										push(errors, [ location, "must be of type integer" ]);
+
+									return value;
+								}
+
+								if (exists(value, "max_age")) {
+									obj.max_age = parseMax_age(location + "/max_age", value["max_age"], errors);
+								}
+								else {
+									obj.max_age = 20;
+								}
+
+								return obj;
+							}
+
+							if (type(value) != "object")
+								push(errors, [ location, "must be of type object" ]);
+
+							return value;
+						}
+
+						return map(value, (item, i) => parseItem(location + "/" + i, item, errors));
+					}
+
+					if (type(value) != "array")
+						push(errors, [ location, "must be of type array" ]);
+
+					return value;
+				}
+
+				if (exists(value, "instances")) {
+					obj.instances = parseInstances(location + "/instances", value["instances"], errors);
+				}
+
 				return obj;
 			}
 

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -767,42 +767,42 @@
                                     "downstream"
                                 ]
                             }
-                        }
-                    },
-                    "instances": {
-                        "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
-                                    "type": "integer"
-                                },
-                                "enabled": {
-                                    "description": "Enable STP on this instance.",
-                                    "type": "boolean",
-                                    "default": true
-                                },
-                                "priority": {
-                                    "description": "Bridge priority.",
-                                    "type": "integer",
-                                    "default": 32768
-                                },
-                                "forward_delay": {
-                                    "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
-                                    "type": "integer",
-                                    "default": 15
-                                },
-                                "hello_time": {
-                                    "description": "Determines how often switches send BPDU.",
-                                    "type": "integer",
-                                    "default": 2
-                                },
-                                "max_age": {
-                                    "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
-                                    "type": "integer",
-                                    "default": 20
+                        },
+                        "instances": {
+                            "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
+                                        "type": "integer"
+                                    },
+                                    "enabled": {
+                                        "description": "Enable STP on this instance.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "priority": {
+                                        "description": "Bridge priority.",
+                                        "type": "integer",
+                                        "default": 32768
+                                    },
+                                    "forward_delay": {
+                                        "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
+                                        "type": "integer",
+                                        "default": 15
+                                    },
+                                    "hello_time": {
+                                        "description": "Determines how often switches send BPDU.",
+                                        "type": "integer",
+                                        "default": 2
+                                    },
+                                    "max_age": {
+                                        "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
+                                        "type": "integer",
+                                        "default": 20
+                                    }
                                 }
                             }
                         }

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -547,35 +547,35 @@
                                     "downstream"
                                 ]
                             }
-                        }
-                    },
-                    "instances": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "type": "integer"
-                                },
-                                "enabled": {
-                                    "type": "boolean",
-                                    "default": true
-                                },
-                                "priority": {
-                                    "type": "integer",
-                                    "default": 32768
-                                },
-                                "forward_delay": {
-                                    "type": "integer",
-                                    "default": 15
-                                },
-                                "hello_time": {
-                                    "type": "integer",
-                                    "default": 2
-                                },
-                                "max_age": {
-                                    "type": "integer",
-                                    "default": 20
+                        },
+                        "instances": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "integer"
+                                    },
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "priority": {
+                                        "type": "integer",
+                                        "default": 32768
+                                    },
+                                    "forward_delay": {
+                                        "type": "integer",
+                                        "default": 15
+                                    },
+                                    "hello_time": {
+                                        "type": "integer",
+                                        "default": 2
+                                    },
+                                    "max_age": {
+                                        "type": "integer",
+                                        "default": 20
+                                    }
                                 }
                             }
                         }

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -618,42 +618,42 @@
                                     "downstream"
                                 ]
                             }
-                        }
-                    },
-                    "instances": {
-                        "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "id": {
-                                    "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
-                                    "type": "integer"
-                                },
-                                "enabled": {
-                                    "description": "Enable STP on this instance.",
-                                    "type": "boolean",
-                                    "default": true
-                                },
-                                "priority": {
-                                    "description": "Bridge priority.",
-                                    "type": "integer",
-                                    "default": 32768
-                                },
-                                "forward_delay": {
-                                    "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
-                                    "type": "integer",
-                                    "default": 15
-                                },
-                                "hello_time": {
-                                    "description": "Determines how often switches send BPDU.",
-                                    "type": "integer",
-                                    "default": 2
-                                },
-                                "max_age": {
-                                    "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
-                                    "type": "integer",
-                                    "default": 20
+                        },
+                        "instances": {
+                            "description": "Define a list of configuration for each STP instance. Meaning of this field depends on current STP protocol (switch.loop-detection.protocol)",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "Indicates instance to configure. Depends on current STP protocol If RPVSTP/PVSTP - vlan id If MSTP - instance id",
+                                        "type": "integer"
+                                    },
+                                    "enabled": {
+                                        "description": "Enable STP on this instance.",
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "priority": {
+                                        "description": "Bridge priority.",
+                                        "type": "integer",
+                                        "default": 32768
+                                    },
+                                    "forward_delay": {
+                                        "description": "Defines the amount of time a switch port stays in the Listening and Learning states before transitioning to the Forwarding state.",
+                                        "type": "integer",
+                                        "default": 15
+                                    },
+                                    "hello_time": {
+                                        "description": "Determines how often switches send BPDU.",
+                                        "type": "integer",
+                                        "default": 2
+                                    },
+                                    "max_age": {
+                                        "description": "Specifies the maximum time that a switch port should wait to receive a BPDU from its neighbor before considering the link as failed or disconnected.",
+                                        "type": "integer",
+                                        "default": 20
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
The property 'instance' is not indented correctly and therefore doesn't end up under the loop-detection properties in the switch configuration. It does end up under loop-detection json object, but essentially creates a tag of 'instances' at the same level as properties, description, etc.
This update corrects the defintion to have the instances array as a property of loop-detection object schema
