### PR TITLE
Add flood-control and querier-enable fields to unit.yml

### DIFF
--- a/schema/unit.yml
+++ b/schema/unit.yml
@@ -100,3 +100,13 @@ properties:
           Global config for controlling whether MLD snooping is enabled. If this global setting is disabled, all VLANs are treated as disabled, whether they are enabled or not.
         type: boolean
         default: true
+      unknown-multicast-flood-control:
+        description:
+          Global config for the unknown multicast flood control feature. This enables the system to forward unknown multicast packets only to a multicast router (mrouter).
+        type: boolean
+        default: false
+      querier-enable:
+        description:
+          Global IGMP querier config. This enables all Vlan interfaces to act as a querier.
+        type: boolean
+        default: false

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -111,6 +111,16 @@
                             "description": "Global config for controlling whether MLD snooping is enabled. If this global setting is disabled, all VLANs are treated as disabled, whether they are enabled or not.",
                             "type": "boolean",
                             "default": true
+                        },
+                        "unknown-multicast-flood-control": {
+                            "description": "Global config for the unknown multicast flood control feature. This enables the system to forward unknown multicast packets only to a multicast router (mrouter).",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "querier-enable": {
+                            "description": "Global IGMP querier config. This enables all Vlan interfaces to act as a querier.",
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 }

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -134,6 +134,14 @@
                         "mld-snooping-enable": {
                             "type": "boolean",
                             "default": true
+                        },
+                        "unknown-multicast-flood-control": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "querier-enable": {
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 }

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -156,6 +156,16 @@
                             "description": "Global config for controlling whether MLD snooping is enabled. If this global setting is disabled, all VLANs are treated as disabled, whether they are enabled or not.",
                             "type": "boolean",
                             "default": true
+                        },
+                        "unknown-multicast-flood-control": {
+                            "description": "Global config for the unknown multicast flood control feature. This enables the system to forward unknown multicast packets only to a multicast router (mrouter).",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "querier-enable": {
+                            "description": "Global IGMP querier config. This enables all Vlan interfaces to act as a querier.",
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 }


### PR DESCRIPTION
These fields are used to specify the global fc and querier configuration.