### PR TITLE
Schema: capabilities: add missed <compatible> field

### DIFF
--- a/capabilities/connect.capabilities.yml
+++ b/capabilities/connect.capabilities.yml
@@ -25,6 +25,10 @@ properties:
     type: string
     description:
       Stock keeping unit
+  compatible:
+    type: string
+    description:
+      Compatibility string, that defines the family of the device
   base-mac:
     type: string
     description:


### PR DESCRIPTION
Connect message is required to have compatible field, as it defines device's <family> of devices and compatible counterparts.

Add this - originally missed - field to the schema, to make sure cloud infrastructure has enough information to deduce device type / compatible devices (for cfg generation etc).