### PR TITLE
[OLS-390] Move uplink_interface definition to state.yml, add version …

### DIFF
--- a/capabilities/connect.capabilities.yml
+++ b/capabilities/connect.capabilities.yml
@@ -12,6 +12,21 @@ properties:
       Platform revision
     examples:
     - Rel 1.6 build 5
+  version:
+    type: object
+    description:
+      The ols schema version to be used with this Switch
+    properties:
+      major:
+        type: integer
+      minor:
+        type: integer
+      patch:
+        type: integer
+    examples:
+      - 'major': 3
+        'minor': 2
+        'patch': 0
   platform:
     type: string
     enum:

--- a/state/interface.ipv4.yml
+++ b/state/interface.ipv4.yml
@@ -12,10 +12,6 @@ properties:
     type: string
     description:
       The public IP address of internet connection.
-  uplink_interface:
-    type: string
-    description:
-      Current interface that serves as the Uplink. Example Ethernet2.
   leasetime:
     type: number
     description:

--- a/state/state.yml
+++ b/state/state.yml
@@ -58,3 +58,7 @@ properties:
     $ref: "https://ucentral.io/state/v1/static-trunks/"
   lacp-trunks:
     $ref: "https://ucentral.io/state/v1/lacp-trunks/"
+  uplink_interface:
+    type: string
+    description:
+      Current interface that serves as the Uplink. Example Ethernet2.

--- a/ucentral.capabilities.pretty.json
+++ b/ucentral.capabilities.pretty.json
@@ -15,6 +15,28 @@
                 "Rel 1.6 build 5"
             ]
         },
+        "version": {
+            "type": "object",
+            "description": "The ols schema version to be used with this Switch",
+            "properties": {
+                "major": {
+                    "type": "integer"
+                },
+                "minor": {
+                    "type": "integer"
+                },
+                "patch": {
+                    "type": "integer"
+                }
+            },
+            "examples": [
+                {
+                    "major": 3,
+                    "minor": 2,
+                    "patch": 0
+                }
+            ]
+        },
         "platform": {
             "type": "string",
             "enum": [

--- a/ucentral.state.pretty.json
+++ b/ucentral.state.pretty.json
@@ -84,6 +84,10 @@
         },
         "lacp-trunks": {
             "$ref": "#/$defs/lacp-trunks"
+        },
+        "uplink_interface": {
+            "type": "string",
+            "description": "Current interface that serves as the Uplink. Example Ethernet2."
         }
     },
     "$defs": {
@@ -334,10 +338,6 @@
                 "public_ip": {
                     "type": "string",
                     "description": "The public IP address of internet connection."
-                },
-                "uplink_interface": {
-                    "type": "string",
-                    "description": "Current interface that serves as the Uplink. Example Ethernet2."
                 },
                 "leasetime": {
                     "type": "number",


### PR DESCRIPTION
The attribute uplink_interface should be under state/state.yml instead of state/interface.ipv4.yml. 
This is already being reported in this manner by the Asterfusion and EdgeCore switches
Add uplink_interface to state/state.yml
```
  uplink_interface:
    type: string
    description:
      Current interface that serves as the Uplink. Example Ethernet2.
```
Schema version should be tracked in the ols-ucentral-schema repo so that it can be reported when the device connects:

Add schema.json to ols-ucentral-client, aligns with wlan-ucentral-schema
```
{
	"major": 3,
	"minor": 2,
	"patch": 0
}
```
capabilities/connect.capabilities.yml, matches the schema.json file definition
```
  version:
    type: object
    description:
      The ols schema version to be used with this Switch
    properties:
      major:
        type: integer
      minor:
        type: integer
      patch:
        type: integer
```
