### PR TITLE
Add attributes (replicate) from ipv4 to ipv4.dhcp

### DIFF
--- a/schema/interface.ipv4.dhcp.yml
+++ b/schema/interface.ipv4.dhcp.yml
@@ -35,4 +35,26 @@ properties:
     type: string
     example:
     - \{Interface\}:\{VLAN-ID\}}
+  remote-id-format:
+    description:
+      This option selects what info shall be contained within a relayed
+      frame's remote ID.
+    type: string
+  use-dns:
+    description:
+      Define which DNS servers shall be used. This can either be a list of
+      static IPv4 addresse or dhcp (use the server provided by the DHCP lease)
+    type: array
+    items:
+      type: string
+      format: ipv4
+      examples:
+      - 8.8.8.8
+      - 4.4.4.4
+  default-router:
+    description:
+      Provide a default router for the pool, so that the route to internet may be established.
+    type: array
+    items:
+      type: string
 

--- a/schema/interface.yml
+++ b/schema/interface.yml
@@ -70,7 +70,7 @@ properties:
     $ref: "https://ucentral.io/schema/v1/interface/ipv6/"
   acl:
     $ref: "https://ucentral.io/schema/v1/interface/acl/"
-  dhcp-snooop-port:
+  dhcp-snoop-port:
     $ref: "https://ucentral.io/schema/v1/interface/dhcp-snoop-port/"
   broad-band:
     $ref: "https://ucentral.io/schema/v1/interface/broad-band/"

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -2469,6 +2469,29 @@
                                         "example": [
                                             "\\{Interface\\}:\\{VLAN-ID\\}}"
                                         ]
+                                    },
+                                    "remote-id-format": {
+                                        "description": "This option selects what info shall be contained within a relayed frame's remote ID.",
+                                        "type": "string"
+                                    },
+                                    "use-dns": {
+                                        "description": "Define which DNS servers shall be used. This can either be a list of static IPv4 addresse or dhcp (use the server provided by the DHCP lease)",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "format": "ipv4",
+                                            "examples": [
+                                                "8.8.8.8",
+                                                "4.4.4.4"
+                                            ]
+                                        }
+                                    },
+                                    "default-router": {
+                                        "description": "Provide a default router for the pool, so that the route to internet may be established.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
                                     }
                                 }
                             },

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -2798,7 +2798,7 @@
                             }
                         }
                     },
-                    "dhcp-snooop-port": {
+                    "dhcp-snoop-port": {
                         "description": "Configuration for DHCP Snooping on a port level on a switch",
                         "type": "object",
                         "properties": {

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -1713,6 +1713,26 @@
                     "example": [
                         "\\{Interface\\}:\\{VLAN-ID\\}}"
                     ]
+                },
+                "remote-id-format": {
+                    "type": "string"
+                },
+                "use-dns": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "ipv4",
+                        "examples": [
+                            "8.8.8.8",
+                            "4.4.4.4"
+                        ]
+                    }
+                },
+                "default-router": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3567,7 +3567,7 @@
                 "acl": {
                     "$ref": "#/$defs/interface.acl"
                 },
-                "dhcp-snooop-port": {
+                "dhcp-snoop-port": {
                     "$ref": "#/$defs/interface.dhcp-snoop-port"
                 },
                 "broad-band": {

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -4122,7 +4122,7 @@
                 "acl": {
                     "$ref": "#/$defs/interface.acl"
                 },
-                "dhcp-snooop-port": {
+                "dhcp-snoop-port": {
                     "$ref": "#/$defs/interface.dhcp-snoop-port"
                 },
                 "broad-band": {

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -1989,6 +1989,29 @@
                     "example": [
                         "\\{Interface\\}:\\{VLAN-ID\\}}"
                     ]
+                },
+                "remote-id-format": {
+                    "description": "This option selects what info shall be contained within a relayed frame's remote ID.",
+                    "type": "string"
+                },
+                "use-dns": {
+                    "description": "Define which DNS servers shall be used. This can either be a list of static IPv4 addresse or dhcp (use the server provided by the DHCP lease)",
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "format": "ipv4",
+                        "examples": [
+                            "8.8.8.8",
+                            "4.4.4.4"
+                        ]
+                    }
+                },
+                "default-router": {
+                    "description": "Provide a default router for the pool, so that the route to internet may be established.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },


### PR DESCRIPTION
- use-dns
- remote-id-format
- default-router

related to doing configuration such as below on ECS
```json 
 "ethernet": [
    {
      "pvid": true,
      "select-ports": [
        "Ethernet2"
      ],
      "vlan-tag": "tagged"
    }
  ],
  "ipv4": {
    "addressing": "static",
    "dhcp": {
      "default-router": [                 <<<<<<--- Set the default router for this pool
        "10.10.3.254"
      ],
      "lease-time": "6h",
      "use-dns": [
        "8.8.8.8",
        "8.8.4.4"
      ]
    },
    "subnet": [
      {
        "prefix": "10.10.3.101/24"
      }
    ]
  },
  "name": "VLAN3",
  "vlan": {
    "id": 3
  }
}
```