### PR TITLE
[OLS-529] Schema: schema/interface.yml incorrect "dhcp-snooop-port"

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -10,7 +10,10 @@ set -x
 ./merge-schema.py capabilities capabilities connect.capabilities.yml ucentral.capabilities.pretty.json 0 1 
 #./generate-reader.uc  > schemareader.uc
 #./generate-example.uc > input.json
-mkdir -p docs
 which generate-schema-doc > /dev/null
 generate-schema-doc --config expand_buttons=true ucentral.schema.pretty.json docs/ucentral-schema.html
 generate-schema-doc --config expand_buttons=true ucentral.state.pretty.json docs/ucentral-state.html
+generate-schema-doc --config expand_buttons=true ucentral.capabilities.pretty.json docs/ucentral.capabilities.html
+generate-schema-doc --config expand_buttons=true ucentral.lldp-peers.pretty.json docs/ucentral.lldp-peers.html
+generate-schema-doc --config expand_buttons=true ucentral.link-state.pretty.json docs/ucentral.link-state.html
+

--- a/schema/interface.yml
+++ b/schema/interface.yml
@@ -70,7 +70,7 @@ properties:
     $ref: "https://ucentral.io/schema/v1/interface/ipv6/"
   acl:
     $ref: "https://ucentral.io/schema/v1/interface/acl/"
-  dhcp-snooop-port:
+  dhcp-snoop-port:
     $ref: "https://ucentral.io/schema/v1/interface/dhcp-snoop-port/"
   broad-band:
     $ref: "https://ucentral.io/schema/v1/interface/broad-band/"

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -2775,7 +2775,7 @@
                             }
                         }
                     },
-                    "dhcp-snooop-port": {
+                    "dhcp-snoop-port": {
                         "description": "Configuration for DHCP Snooping on a port level on a switch",
                         "type": "object",
                         "properties": {

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -3547,7 +3547,7 @@
                 "acl": {
                     "$ref": "#/$defs/interface.acl"
                 },
-                "dhcp-snooop-port": {
+                "dhcp-snoop-port": {
                     "$ref": "#/$defs/interface.dhcp-snoop-port"
                 },
                 "broad-band": {

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -4099,7 +4099,7 @@
                 "acl": {
                     "$ref": "#/$defs/interface.acl"
                 },
-                "dhcp-snooop-port": {
+                "dhcp-snoop-port": {
                     "$ref": "#/$defs/interface.dhcp-snoop-port"
                 },
                 "broad-band": {


### PR DESCRIPTION
schema/interface.yml
Fix:
  dhcp-snooop-port:
    $ref: "https://ucentral.io/schema/v1/interface/dhcp-snoop-port/"

Change to:
  dhcp-snoop-port:
    $ref: "https://ucentral.io/schema/v1/interface/dhcp-snoop-port/"