### PR TITLE
Fix broken schema json file

### DIFF
--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -773,6 +773,7 @@
                         "description": "When true, the port behaves as an STP Edge Port. When false, the port participates fully in STP and is treated as a normal switch port.",
                         "type": "boolean",
                         "default": false
+                    },
                     "storm-control": {
                         "description": "Storm Control configuration per storm type. Allows enabling or disabling traffic storm control for broadcast, multicast, and unknown unicast packets, with independent packet-per-second (pps) thresholds. A limit-pps value of 0 implies the control is disabled for that traffic type.",
                         "type": "object",

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -684,6 +684,7 @@
                 "edge-port": {
                     "type": "boolean",
                     "default": false
+                },
                 "storm-control": {
                     "type": "object",
                     "properties": null,

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -807,6 +807,7 @@
                     "description": "When true, the port behaves as an STP Edge Port. When false, the port participates fully in STP and is treated as a normal switch port.",
                     "type": "boolean",
                     "default": false
+                },
                 "storm-control": {
                     "description": "Storm Control configuration per storm type. Allows enabling or disabling traffic storm control for broadcast, multicast, and unknown unicast packets, with independent packet-per-second (pps) thresholds. A limit-pps value of 0 implies the control is disabled for that traffic type.",
                     "type": "object",


### PR DESCRIPTION
After latest main merge, there's some overlapping which effectively breaks the schema (it becomes invalid json file, due to some objects not ending where they should).

Run generate.sh to provide a complete valid generated json file.