### PR TITLE
Fix indentation for storm-control configuration.

### DIFF
--- a/schema/ethernet.yml
+++ b/schema/ethernet.yml
@@ -522,18 +522,18 @@ properties:
       with independent packet-per-second (pps) thresholds. A limit-pps value of 0 implies the control is disabled for that traffic type.
     type: object
     properties:
-    broadcast-pps:
-      type: integer
-      minimum: 0
-      default: 0
-      description: Maximum allowed broadcast packets per second. 0 disables broadcast storm control.
-    multicast-pps:
-      type: integer
-      minimum: 0
-      default: 0
-      description: Maximum allowed multicast packets per second. 0 disables multicast storm control.
-    unknown-unicast-pps:
-      type: integer
-      minimum: 0
-      default: 0
-      description:  Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control.
+      broadcast-pps:
+        type: integer
+        minimum: 0
+        default: 0
+        description: Maximum allowed broadcast packets per second. 0 disables broadcast storm control.
+      multicast-pps:
+        type: integer
+        minimum: 0
+        default: 0
+        description: Maximum allowed multicast packets per second. 0 disables multicast storm control.
+      unknown-unicast-pps:
+        type: integer
+        minimum: 0
+        default: 0
+        description:  Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control.

--- a/ucentral.schema.full.json
+++ b/ucentral.schema.full.json
@@ -777,24 +777,25 @@
                     "storm-control": {
                         "description": "Storm Control configuration per storm type. Allows enabling or disabling traffic storm control for broadcast, multicast, and unknown unicast packets, with independent packet-per-second (pps) thresholds. A limit-pps value of 0 implies the control is disabled for that traffic type.",
                         "type": "object",
-                        "properties": null,
-                        "broadcast-pps": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "default": 0,
-                            "description": "Maximum allowed broadcast packets per second. 0 disables broadcast storm control."
-                        },
-                        "multicast-pps": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "default": 0,
-                            "description": "Maximum allowed multicast packets per second. 0 disables multicast storm control."
-                        },
-                        "unknown-unicast-pps": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "default": 0,
-                            "description": "Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control."
+                        "properties": {
+                            "broadcast-pps": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "default": 0,
+                                "description": "Maximum allowed broadcast packets per second. 0 disables broadcast storm control."
+                            },
+                            "multicast-pps": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "default": 0,
+                                "description": "Maximum allowed multicast packets per second. 0 disables multicast storm control."
+                            },
+                            "unknown-unicast-pps": {
+                                "type": "integer",
+                                "minimum": 0,
+                                "default": 0,
+                                "description": "Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control."
+                            }
                         }
                     }
                 }

--- a/ucentral.schema.json
+++ b/ucentral.schema.json
@@ -687,21 +687,22 @@
                 },
                 "storm-control": {
                     "type": "object",
-                    "properties": null,
-                    "broadcast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0
-                    },
-                    "multicast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0
-                    },
-                    "unknown-unicast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0
+                    "properties": {
+                        "broadcast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "multicast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0
+                        },
+                        "unknown-unicast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0
+                        }
                     }
                 }
             }

--- a/ucentral.schema.pretty.json
+++ b/ucentral.schema.pretty.json
@@ -811,24 +811,25 @@
                 "storm-control": {
                     "description": "Storm Control configuration per storm type. Allows enabling or disabling traffic storm control for broadcast, multicast, and unknown unicast packets, with independent packet-per-second (pps) thresholds. A limit-pps value of 0 implies the control is disabled for that traffic type.",
                     "type": "object",
-                    "properties": null,
-                    "broadcast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0,
-                        "description": "Maximum allowed broadcast packets per second. 0 disables broadcast storm control."
-                    },
-                    "multicast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0,
-                        "description": "Maximum allowed multicast packets per second. 0 disables multicast storm control."
-                    },
-                    "unknown-unicast-pps": {
-                        "type": "integer",
-                        "minimum": 0,
-                        "default": 0,
-                        "description": "Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control."
+                    "properties": {
+                        "broadcast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "description": "Maximum allowed broadcast packets per second. 0 disables broadcast storm control."
+                        },
+                        "multicast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "description": "Maximum allowed multicast packets per second. 0 disables multicast storm control."
+                        },
+                        "unknown-unicast-pps": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                            "description": "Maximum allowed unknown unicast packets per second. 0 disables unknown unicast storm control."
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Indentation is wrong for storm control ends up having no properties defined in the generated schema
corrected indentation and regenerated json
